### PR TITLE
Bug in getNum(..) function

### DIFF
--- a/helperFuncts.h
+++ b/helperFuncts.h
@@ -10,7 +10,7 @@
  long getNum(unsigned char* a, int start, int size) {
 	unsigned long result = 0, shift = 8 * (size - 1);
 	for (unsigned long i = start; i < start + size; i++) {
-		result |= a[i] << shift;
+		result |= (unsigned long)a[i] << shift;
 		shift -= 8;
 	}
 	return result;

--- a/readPNG.c
+++ b/readPNG.c
@@ -53,7 +53,7 @@ void readPNG(char* path, int verbose) {
 	fclose(file);
 
 	printf("\t----\nfile-path=%s\n", path);
-	printf("file-size=%d bytes\n", lSize);
+	printf("file-size=%ld bytes\n", lSize);
 	processPNG(buffer, lSize, verbose);
 
 	free(buffer);


### PR DESCRIPTION
Lack of early cast of input byte in getNum(..) resulted in some negative values created. These values were then casted to unsigned and back to signed long.

By the way I corrected an incorrect size specifier in printf format string too. It's a minor issue.